### PR TITLE
feat: implement OrganizationEventsResource and UserEventsResource classes

### DIFF
--- a/src/core/resources/organizations/events.ts
+++ b/src/core/resources/organizations/events.ts
@@ -1,0 +1,11 @@
+import { OrganizationEvent } from "../../../types"
+import { BaseResource } from "../base"
+
+
+export class OrganizationEventsResource extends BaseResource {
+    readonly endpoint = 'organizations/events'
+
+    async post<T = unknown>(data: OrganizationEvent[]): Promise<T> {
+        return super.post(data)
+    }
+}

--- a/src/core/resources/organizations/index.ts
+++ b/src/core/resources/organizations/index.ts
@@ -1,2 +1,3 @@
 export { OrganizationResource } from './organization'
 export { OrganizationScheduledResource } from './scheduled'
+export { OrganizationEventsResource } from './events'

--- a/src/core/resources/organizations/organization.ts
+++ b/src/core/resources/organizations/organization.ts
@@ -1,16 +1,19 @@
-import { DeleteOrganizationRequest, OrganizationEvent, OrganizationRequest, OrganizationUserRequest, RemoveOrganizationUserRequest } from "../../../types"
+import { DeleteOrganizationRequest, OrganizationRequest, OrganizationUserRequest, RemoveOrganizationUserRequest } from "../../../types"
 import { BaseResource } from "../base"
 import { HttpHandler } from "../../http"
 import { OrganizationScheduledResource } from "./scheduled"
+import { OrganizationEventsResource } from "./events"
 
 
 export class OrganizationResource extends BaseResource {
     readonly endpoint = 'organizations'
     readonly schedule: OrganizationScheduledResource
+    readonly events: OrganizationEventsResource
 
     constructor(http: HttpHandler) {
         super(http)
         this.schedule = new OrganizationScheduledResource(http)
+        this.events = new OrganizationEventsResource(http)
     }
 
     /**
@@ -47,14 +50,5 @@ export class OrganizationResource extends BaseResource {
      */
     async removeUser(data: RemoveOrganizationUserRequest) {
         return this.remove(data, 'organizations/users')
-    }
-
-    /**
-     * Posts events for an organization.
-     * @param data - Array of organization events to post
-     * @returns Promise resolving to the API response
-     */
-    async postEvents(data: OrganizationEvent[]) {
-        return this.post(data, 'organizations/events')
     }
 }

--- a/src/core/resources/users/events.ts
+++ b/src/core/resources/users/events.ts
@@ -1,0 +1,11 @@
+import { UserEvent } from "../../../types"
+import { BaseResource } from "../base"
+
+
+export class UserEventsResource extends BaseResource {
+    readonly endpoint = 'users/events'
+
+    async post<T = unknown>(data: UserEvent[]): Promise<T> {
+        return super.post(data)
+    }
+}

--- a/src/core/resources/users/index.ts
+++ b/src/core/resources/users/index.ts
@@ -1,2 +1,3 @@
 export { UserResource } from './user'
 export { UserScheduledResource } from './scheduled'
+export { UserEventsResource } from './events'

--- a/src/core/resources/users/user.ts
+++ b/src/core/resources/users/user.ts
@@ -3,17 +3,19 @@ import { HttpHandler } from '../../http'
 import {
     UpsertUserRequest,
     DeleteUserRequest,
-    UserEvent,
 } from '../../../types'
 import { UserScheduledResource } from './scheduled'
+import { UserEventsResource } from './events'
 
 export class UserResource extends BaseResource {
     readonly endpoint = 'users'
     readonly schedule: UserScheduledResource
+    readonly events: UserEventsResource
 
     constructor(http: HttpHandler) {
         super(http)
         this.schedule = new UserScheduledResource(http)
+        this.events = new UserEventsResource(http)
     }
 
     /**
@@ -32,14 +34,5 @@ export class UserResource extends BaseResource {
      */
     async delete(data: DeleteUserRequest) {
         return this.remove(data)
-    }
-
-    /**
-     * Posts events for a user.
-     * @param data - Array of user events to post
-     * @returns Promise resolving to the API response
-     */
-    async postEvents(data: UserEvent[]) {
-        return this.post(data, 'users/events')
     }
 }


### PR DESCRIPTION
## Summary

Split events into separate resources for both organizations and users, following the same pattern used for scheduled resources.

## Changes

- Created `OrganizationEventsResource` in `src/core/resources/organizations/events.ts` with `post()` method
- Created `UserEventsResource` in `src/core/resources/users/events.ts` with `post()` method
- Updated `OrganizationResource` and `UserResource` to expose events as a nested property
- Removed `postEvents` methods from the main resource classes

## Usage

```typescript
// Organization events
client.organizations.events.post([...])

// User events
client.users.events.post([...])
```